### PR TITLE
adding more tests 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rocksdb = "0.22.0"
 byte-unit = "5.1.6"
 getset = "0.1.3"
 chrono = "0.4"
+tempfile = "3.15.0"
 
 [dev-dependencies]
 rstest = "0.23.0"

--- a/src/primary/header_elector.rs
+++ b/src/primary/header_elector.rs
@@ -152,9 +152,7 @@ mod test {
 
     use crate::{
         db::{Column, Db},
-        primary::test_utils::fixtures::{
-            random_digests, CHANNEL_CAPACITY,
-        },
+        primary::test_utils::fixtures::{random_digests, CHANNEL_CAPACITY},
         settings::parser::Committee,
         types::{
             block_header::BlockHeader,
@@ -187,20 +185,20 @@ mod test {
         let (round_tx, round_rx) = watch::channel((0, HashSet::new()));
         let (incomplete_headers_tx, incomplete_headers_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let (network_tx, network_rx) = mpsc::channel(CHANNEL_CAPACITY);
-        
+
         // Create a temporary directory for the test database
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        
+
         let db = Arc::new(Db::new(db_path).unwrap());
-        
+
         let validator_keypair = ed25519::Keypair::generate();
         let token = CancellationToken::new();
         let db_clone = db.clone();
         let token_clone = token.clone();
-        
+
         let committee = Committee::new_test();
-        
+
         tokio::spawn(async move {
             HeaderElector::spawn(
                 token_clone,
@@ -215,7 +213,7 @@ mod test {
             .await
             .unwrap()
         });
-        
+
         (
             headers_tx,
             round_tx,

--- a/src/primary/mod.rs
+++ b/src/primary/mod.rs
@@ -259,3 +259,8 @@ impl BaseAgent for Primary {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    mod header_tests;
+}

--- a/src/primary/tests/header_tests.rs
+++ b/src/primary/tests/header_tests.rs
@@ -77,6 +77,7 @@ async fn test_wait_for_quorum() {
 
 #[tokio::test]
 async fn test_header_builder_sync_status() {
+    // Test initialization
     let (network_tx, _) = mpsc::channel(100);
     let (certificate_tx, _) = mpsc::channel(100);
     let keypair = Keypair::generate();
@@ -87,6 +88,7 @@ async fn test_header_builder_sync_status() {
     let committee = Committee::new_test();
     let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Incomplete);
 
+    // Verify initialization by creating header builder
     let header_builder = HeaderBuilder {
         network_tx,
         certificate_tx,
@@ -99,7 +101,7 @@ async fn test_header_builder_sync_status() {
         sync_status_rx,
     };
 
-    // run header builder
+    // Run header builder in background
     let handle = tokio::spawn(async move {
         header_builder.run().await.unwrap();
     });
@@ -107,7 +109,7 @@ async fn test_header_builder_sync_status() {
     // Test that header builder waits for sync to complete
     sleep(Duration::from_millis(100)).await;
     sync_status_tx.send(SyncStatus::Complete).unwrap();
-
+    
     handle.abort();
 }
 

--- a/src/primary/tests/header_tests.rs
+++ b/src/primary/tests/header_tests.rs
@@ -1,0 +1,314 @@
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use libp2p::identity::ed25519::Keypair;
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    time::sleep,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    db::Db,
+    primary::header_builder::{wait_for_quorum, HeaderBuilder},
+    settings::parser::Committee,
+    types::{
+        batch::BatchId,
+        block_header::BlockHeader,
+        certificate::Certificate,
+        network::{NetworkRequest, ReceivedObject},
+        sync::SyncStatus,
+        vote::Vote,
+        Round,
+    },
+    utils::CircularBuffer,
+};
+
+#[tokio::test]
+async fn test_header_builder_initialization() {
+    let (network_tx, _) = mpsc::channel(100);
+    let (certificate_tx, _) = mpsc::channel(100);
+    let keypair = Keypair::generate();
+    let db = Arc::new(Db::new_in_memory().await.unwrap());
+    let (header_trigger_tx, header_trigger_rx) = watch::channel((0, HashSet::new()));
+    let (votes_tx, votes_rx) = broadcast::channel(100);
+    let digests_buffer = Arc::new(tokio::sync::Mutex::new(CircularBuffer::new(100)));
+    let committee = Committee::new_test();
+    let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
+
+    let _header_builder = HeaderBuilder {
+        network_tx,
+        certificate_tx,
+        keypair,
+        _db: db,
+        header_trigger_rx,
+        votes_rx,
+        digests_buffer,
+        committee,
+        sync_status_rx,
+    };
+}
+
+#[tokio::test]
+async fn test_wait_for_quorum() {
+    let keypair = Keypair::generate();
+    let (votes_tx, mut votes_rx) = broadcast::channel(100);
+    let header = BlockHeader::new_test();
+    let threshold = 2;
+
+    // send votes
+    tokio::spawn(async move {
+        for i in 0..threshold {
+            let vote = Vote::new_test();
+            let received = ReceivedObject {
+                object: vote,
+                peer_id: format!("peer_{}", i),
+            };
+            votes_tx.send(received).unwrap();
+            sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    // Wait for quorum
+    let result = wait_for_quorum(&header, threshold, &mut votes_rx, &keypair).await;
+    assert!(result.is_ok());
+    let votes = result.unwrap();
+    assert_eq!(votes.len(), threshold);
+}
+
+#[tokio::test]
+async fn test_header_builder_sync_status() {
+    let (network_tx, _) = mpsc::channel(100);
+    let (certificate_tx, _) = mpsc::channel(100);
+    let keypair = Keypair::generate();
+    let db = Arc::new(Db::new_in_memory().await.unwrap());
+    let (header_trigger_tx, header_trigger_rx) = watch::channel((0, HashSet::new()));
+    let (votes_tx, votes_rx) = broadcast::channel(100);
+    let digests_buffer = Arc::new(tokio::sync::Mutex::new(CircularBuffer::new(100)));
+    let committee = Committee::new_test();
+    let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Incomplete);
+
+    let header_builder = HeaderBuilder {
+        network_tx,
+        certificate_tx,
+        keypair,
+        _db: db,
+        header_trigger_rx,
+        votes_rx,
+        digests_buffer,
+        committee,
+        sync_status_rx,
+    };
+
+    // run header builder
+    let handle = tokio::spawn(async move {
+        header_builder.run().await.unwrap();
+    });
+
+    // Test that header builder waits for sync to complete
+    sleep(Duration::from_millis(100)).await;
+    sync_status_tx.send(SyncStatus::Complete).unwrap();
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_header_builder_with_empty_digests() {
+    let (network_tx, _) = mpsc::channel(100);
+    let (certificate_tx, _) = mpsc::channel(100);
+    let keypair = Keypair::generate();
+    let db = Arc::new(Db::new_in_memory().await.unwrap());
+    let (header_trigger_tx, header_trigger_rx) = watch::channel((0, HashSet::new()));
+    let (votes_tx, votes_rx) = broadcast::channel(100);
+    let digests_buffer = Arc::new(tokio::sync::Mutex::new(CircularBuffer::new(100)));
+    let committee = Committee::new_test();
+    let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
+
+    let header_builder = HeaderBuilder {
+        network_tx,
+        certificate_tx,
+        keypair,
+        _db: db,
+        header_trigger_rx,
+        votes_rx,
+        digests_buffer,
+        committee,
+        sync_status_rx,
+    };
+
+    // run header builder
+    let handle = tokio::spawn(async move {
+        header_builder.run().await.unwrap();
+    });
+
+    // trigger header building with empty digests
+    header_trigger_tx.send((1, HashSet::new())).unwrap();
+    sleep(Duration::from_millis(100)).await;
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_header_builder_multiple_rounds() {
+    let (network_tx, _) = mpsc::channel(100);
+    let (certificate_tx, mut cert_rx) = mpsc::channel(100);
+    let keypair = Keypair::generate();
+    let db = Arc::new(Db::new_in_memory().await.unwrap());
+    let (header_trigger_tx, header_trigger_rx) = watch::channel((0, HashSet::new()));
+    let (votes_tx, votes_rx) = broadcast::channel(100);
+    let digests_buffer = Arc::new(tokio::sync::Mutex::new(CircularBuffer::new(100)));
+    let committee = Committee::new_test();
+    let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
+
+    let header_builder = HeaderBuilder {
+        network_tx,
+        certificate_tx,
+        keypair,
+        _db: db,
+        header_trigger_rx,
+        votes_rx,
+        digests_buffer,
+        committee,
+        sync_status_rx,
+    };
+
+    // run header builder
+    let handle = tokio::spawn(async move {
+        header_builder.run().await.unwrap();
+    });
+
+    // trigger multiple rounds
+    for round in 1..=3 {
+        let mut certs = HashSet::new();
+        certs.insert(Certificate::genesis([round as u8; 32]));
+        header_trigger_tx.send((round, certs)).unwrap();
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_header_builder_quorum_timeout() {
+    let (network_tx, _) = mpsc::channel(100);
+    let (certificate_tx, _) = mpsc::channel(100);
+    let keypair = Keypair::generate();
+    let db = Arc::new(Db::new_in_memory().await.unwrap());
+    let (header_trigger_tx, header_trigger_rx) = watch::channel((0, HashSet::new()));
+    let (votes_tx, votes_rx) = broadcast::channel(100);
+    let digests_buffer = Arc::new(tokio::sync::Mutex::new(CircularBuffer::new(100)));
+    let committee = Committee::new_test();
+    let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
+
+    let header_builder = HeaderBuilder {
+        network_tx,
+        certificate_tx,
+        keypair,
+        _db: db,
+        header_trigger_rx,
+        votes_rx,
+        digests_buffer,
+        committee,
+        sync_status_rx,
+    };
+
+    // run header builder
+    let handle = tokio::spawn(async move {
+        header_builder.run().await.unwrap();
+    });
+
+    // trigger header building but don't send any votes
+    let mut certs = HashSet::new();
+    certs.insert(Certificate::genesis([0; 32]));
+    header_trigger_tx.send((1, certs)).unwrap();
+
+    // wait for timeout duration
+    sleep(Duration::from_millis(110)).await;
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_header_builder_invalid_votes() {
+    let (network_tx, _) = mpsc::channel(100);
+    let (certificate_tx, _) = mpsc::channel(100);
+    let keypair = Keypair::generate();
+    let db = Arc::new(Db::new_in_memory().await.unwrap());
+    let (header_trigger_tx, header_trigger_rx) = watch::channel((0, HashSet::new()));
+    let (votes_tx, votes_rx) = broadcast::channel(100);
+    let digests_buffer = Arc::new(tokio::sync::Mutex::new(CircularBuffer::new(100)));
+    let committee = Committee::new_test();
+    let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
+
+    let header_builder = HeaderBuilder {
+        network_tx,
+        certificate_tx,
+        keypair,
+        _db: db,
+        header_trigger_rx,
+        votes_rx,
+        digests_buffer,
+        committee,
+        sync_status_rx,
+    };
+
+    // run header builder
+    let handle = tokio::spawn(async move {
+        header_builder.run().await.unwrap();
+    });
+
+    // send invalid votes
+    let invalid_vote = Vote::new_test_invalid();
+    votes_tx.send(ReceivedObject::new(invalid_vote, "peer1".to_string())).unwrap();
+
+    sleep(Duration::from_millis(10)).await;
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_header_builder_digest_buffer() {
+    let (network_tx, _) = mpsc::channel(100);
+    let (certificate_tx, _) = mpsc::channel(100);
+    let keypair = Keypair::generate();
+    let db = Arc::new(Db::new_in_memory().await.unwrap());
+    let (header_trigger_tx, header_trigger_rx) = watch::channel((0, HashSet::new()));
+    let (votes_tx, votes_rx) = broadcast::channel(100);
+    let digests_buffer = Arc::new(tokio::sync::Mutex::new(CircularBuffer::new(2))); // Small buffer
+    let committee = Committee::new_test();
+    let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
+
+    let header_builder = HeaderBuilder {
+        network_tx,
+        certificate_tx,
+        keypair,
+        _db: db,
+        header_trigger_rx,
+        votes_rx,
+        digests_buffer: digests_buffer.clone(),
+        committee,
+        sync_status_rx,
+    };
+
+    // Run header builder in background
+    let handle = tokio::spawn(async move {
+        header_builder.run().await.unwrap();
+    });
+
+    // Add digests to buffer
+    {
+        let mut buffer = digests_buffer.lock().await;
+        buffer.push(BatchId::new([1; 32]));
+        buffer.push(BatchId::new([2; 32]));
+        // This should overwrite the first digest
+        buffer.push(BatchId::new([3; 32]));
+    }
+
+    // Verify buffer state
+    {
+        let buffer = digests_buffer.lock().await;
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer.as_slice()[0], BatchId::new([2; 32]));
+        assert_eq!(buffer.as_slice()[1], BatchId::new([3; 32]));
+    }
+
+    handle.abort();
+} 

--- a/src/primary/tests/header_tests.rs
+++ b/src/primary/tests/header_tests.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
-use libp2p::identity::ed25519::Keypair;
+use libp2p::{identity::ed25519::Keypair, PeerId};
 use tokio::{
     sync::{broadcast, mpsc, watch},
     time::sleep,
@@ -17,11 +17,76 @@ use crate::{
         certificate::Certificate,
         network::{NetworkRequest, ReceivedObject},
         sync::SyncStatus,
+        traits::AsBytes,
+        signing::Signable,
         vote::Vote,
         Round,
     },
     utils::CircularBuffer,
 };
+
+// First, let's create test helper functions
+impl BlockHeader {
+    #[cfg(test)]
+    pub fn new_test() -> Self {
+        let peer_id = PeerId::random();
+        let mut author = [0u8; 32];
+        let peer_bytes = peer_id.to_bytes();
+        let hash = blake3::hash(&peer_bytes);
+        author.copy_from_slice(hash.as_bytes());
+        
+        Self {
+            round: 1,
+            author,
+            timestamp_ms: chrono::Utc::now().timestamp_millis() as u128,
+            certificates_ids: vec![],
+            digests: vec![],
+        }
+    }
+}
+
+impl Vote {
+    #[cfg(test)]
+    pub fn new_test() -> Self {
+        let keypair = Keypair::generate();
+        let authority = keypair.public().to_bytes();
+        let header = BlockHeader::new_test();
+        let signature = header.sign(&keypair).unwrap();
+        
+        Self {
+            authority,
+            signature,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_test_invalid() -> Self {
+        let keypair = Keypair::generate();
+        let authority = keypair.public().to_bytes();
+        
+        Self {
+            authority,
+            signature: vec![0; 32],
+        }
+    }
+}
+
+impl Db {
+    #[cfg(test)]
+    pub async fn new_in_memory() -> anyhow::Result<Self> {
+        let temp_dir = tempfile::tempdir()?;
+        Self::new(temp_dir.path().to_path_buf())
+    }
+}
+
+impl BatchId {
+    #[cfg(test)]
+    pub fn test_digest(value: u8) -> Self {
+        let mut digest = [0u8; 32];
+        digest.fill(value);
+        Self(digest)
+    }
+}
 
 #[tokio::test]
 async fn test_header_builder_initialization() {
@@ -35,17 +100,20 @@ async fn test_header_builder_initialization() {
     let committee = Committee::new_test();
     let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
 
-    let _header_builder = HeaderBuilder {
+    let handle = HeaderBuilder::spawn(
+        CancellationToken::new(),
         network_tx,
         certificate_tx,
         keypair,
-        _db: db,
+        db,
         header_trigger_rx,
         votes_rx,
         digests_buffer,
         committee,
         sync_status_rx,
-    };
+    );
+
+    handle.abort();
 }
 
 #[tokio::test]
@@ -55,13 +123,17 @@ async fn test_wait_for_quorum() {
     let header = BlockHeader::new_test();
     let threshold = 2;
 
+    // Create votes before spawning the task
+    let votes: Vec<_> = (0..threshold)
+        .map(|_| Vote::from_header(header.clone(), &keypair).unwrap())
+        .collect();
+
     // send votes
     tokio::spawn(async move {
-        for i in 0..threshold {
-            let vote = Vote::new_test();
+        for vote in votes {
             let received = ReceivedObject {
                 object: vote,
-                peer_id: format!("peer_{}", i),
+                sender: PeerId::random(),
             };
             votes_tx.send(received).unwrap();
             sleep(Duration::from_millis(100)).await;
@@ -77,7 +149,6 @@ async fn test_wait_for_quorum() {
 
 #[tokio::test]
 async fn test_header_builder_sync_status() {
-    // Test initialization
     let (network_tx, _) = mpsc::channel(100);
     let (certificate_tx, _) = mpsc::channel(100);
     let keypair = Keypair::generate();
@@ -88,23 +159,19 @@ async fn test_header_builder_sync_status() {
     let committee = Committee::new_test();
     let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Incomplete);
 
-    // Verify initialization by creating header builder
-    let header_builder = HeaderBuilder {
+    // Spawn header builder - it returns a JoinHandle
+    let handle = HeaderBuilder::spawn(
+        CancellationToken::new(),
         network_tx,
         certificate_tx,
         keypair,
-        _db: db,
+        db,
         header_trigger_rx,
         votes_rx,
         digests_buffer,
         committee,
         sync_status_rx,
-    };
-
-    // Run header builder in background
-    let handle = tokio::spawn(async move {
-        header_builder.run().await.unwrap();
-    });
+    );
 
     // Test that header builder waits for sync to complete
     sleep(Duration::from_millis(100)).await;
@@ -125,22 +192,18 @@ async fn test_header_builder_with_empty_digests() {
     let committee = Committee::new_test();
     let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
 
-    let header_builder = HeaderBuilder {
+    let handle = HeaderBuilder::spawn(
+        CancellationToken::new(),
         network_tx,
         certificate_tx,
         keypair,
-        _db: db,
+        db,
         header_trigger_rx,
         votes_rx,
         digests_buffer,
         committee,
         sync_status_rx,
-    };
-
-    // run header builder
-    let handle = tokio::spawn(async move {
-        header_builder.run().await.unwrap();
-    });
+    );
 
     // trigger header building with empty digests
     header_trigger_tx.send((1, HashSet::new())).unwrap();
@@ -161,22 +224,18 @@ async fn test_header_builder_multiple_rounds() {
     let committee = Committee::new_test();
     let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
 
-    let header_builder = HeaderBuilder {
+    let handle = HeaderBuilder::spawn(
+        CancellationToken::new(),
         network_tx,
         certificate_tx,
         keypair,
-        _db: db,
+        db,
         header_trigger_rx,
         votes_rx,
         digests_buffer,
         committee,
         sync_status_rx,
-    };
-
-    // run header builder
-    let handle = tokio::spawn(async move {
-        header_builder.run().await.unwrap();
-    });
+    );
 
     // trigger multiple rounds
     for round in 1..=3 {
@@ -201,31 +260,25 @@ async fn test_header_builder_quorum_timeout() {
     let committee = Committee::new_test();
     let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
 
-    let header_builder = HeaderBuilder {
+    let handle = HeaderBuilder::spawn(
+        CancellationToken::new(),
         network_tx,
         certificate_tx,
         keypair,
-        _db: db,
+        db,
         header_trigger_rx,
         votes_rx,
         digests_buffer,
         committee,
         sync_status_rx,
-    };
-
-    // run header builder
-    let handle = tokio::spawn(async move {
-        header_builder.run().await.unwrap();
-    });
+    );
 
     // trigger header building but don't send any votes
     let mut certs = HashSet::new();
     certs.insert(Certificate::genesis([0; 32]));
     header_trigger_tx.send((1, certs)).unwrap();
 
-    // wait for timeout duration
     sleep(Duration::from_millis(110)).await;
-
     handle.abort();
 }
 
@@ -241,26 +294,25 @@ async fn test_header_builder_invalid_votes() {
     let committee = Committee::new_test();
     let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
 
-    let header_builder = HeaderBuilder {
+    let handle = HeaderBuilder::spawn(
+        CancellationToken::new(),
         network_tx,
         certificate_tx,
         keypair,
-        _db: db,
+        db,
         header_trigger_rx,
         votes_rx,
         digests_buffer,
         committee,
         sync_status_rx,
-    };
-
-    // run header builder
-    let handle = tokio::spawn(async move {
-        header_builder.run().await.unwrap();
-    });
+    );
 
     // send invalid votes
     let invalid_vote = Vote::new_test_invalid();
-    votes_tx.send(ReceivedObject::new(invalid_vote, "peer1".to_string())).unwrap();
+    votes_tx.send(ReceivedObject {
+        object: invalid_vote,
+        sender: PeerId::random(),
+    }).unwrap();
 
     sleep(Duration::from_millis(10)).await;
     handle.abort();
@@ -278,38 +330,34 @@ async fn test_header_builder_digest_buffer() {
     let committee = Committee::new_test();
     let (sync_status_tx, sync_status_rx) = watch::channel(SyncStatus::Complete);
 
-    let header_builder = HeaderBuilder {
+    let handle = HeaderBuilder::spawn(
+        CancellationToken::new(),
         network_tx,
         certificate_tx,
         keypair,
-        _db: db,
+        db,
         header_trigger_rx,
         votes_rx,
-        digests_buffer: digests_buffer.clone(),
+        digests_buffer.clone(),
         committee,
         sync_status_rx,
-    };
-
-    // Run header builder in background
-    let handle = tokio::spawn(async move {
-        header_builder.run().await.unwrap();
-    });
+    );
 
     // Add digests to buffer
     {
         let mut buffer = digests_buffer.lock().await;
-        buffer.push(BatchId::new([1; 32]));
-        buffer.push(BatchId::new([2; 32]));
-        // This should overwrite the first digest
-        buffer.push(BatchId::new([3; 32]));
+        buffer.push(BatchId::test_digest(1));
+        buffer.push(BatchId::test_digest(2));
+        buffer.push(BatchId::test_digest(3));
     }
 
     // Verify buffer state
     {
-        let buffer = digests_buffer.lock().await;
-        assert_eq!(buffer.len(), 2);
-        assert_eq!(buffer.as_slice()[0], BatchId::new([2; 32]));
-        assert_eq!(buffer.as_slice()[1], BatchId::new([3; 32]));
+        let mut buffer = digests_buffer.lock().await;
+        let contents = buffer.drain();
+        assert_eq!(contents.len(), 2);
+        assert_eq!(contents[0], BatchId::test_digest(2));
+        assert_eq!(contents[1], BatchId::test_digest(3));
     }
 
     handle.abort();

--- a/src/primary/tests/header_tests.rs
+++ b/src/primary/tests/header_tests.rs
@@ -25,7 +25,7 @@ use crate::{
     utils::CircularBuffer,
 };
 
-// First, let's create test helper functions
+// test helper functions
 impl BlockHeader {
     #[cfg(test)]
     pub fn new_test() -> Self {

--- a/src/settings/parser.rs
+++ b/src/settings/parser.rs
@@ -1,4 +1,7 @@
-use libp2p::{identity::{self, ed25519}, PeerId};
+use libp2p::{
+    identity::{self, ed25519},
+    PeerId,
+};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -45,13 +48,13 @@ impl Committee {
     #[cfg(test)]
     pub fn new_test() -> Self {
         let mut authorities = Vec::new();
-        
+
         // Add three test authorities
         for i in 0..3 {
             let keypair = ed25519::Keypair::generate();
             let public_key = identity::PublicKey::from(keypair.public());
             let peer_id = PeerId::from_public_key(&public_key);
-            
+
             let authority = AuthorityInfo {
                 authority_id: peer_id,
                 authority_pubkey: hex::encode(keypair.public().to_bytes()),
@@ -61,7 +64,7 @@ impl Committee {
             };
             authorities.push(authority);
         }
-        
+
         Committee { authorities }
     }
 }

--- a/src/settings/parser.rs
+++ b/src/settings/parser.rs
@@ -1,4 +1,4 @@
-use libp2p::PeerId;
+use libp2p::{identity::{self, ed25519}, PeerId};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -37,8 +37,32 @@ impl Committee {
         }
         ((self.authorities.len() / 3) * 2 + 1) as u32
     }
+
     pub fn has_authority_id(&self, peer_id: &PeerId) -> bool {
         self.authorities.iter().any(|a| &a.authority_id == peer_id)
+    }
+
+    #[cfg(test)]
+    pub fn new_test() -> Self {
+        let mut authorities = Vec::new();
+        
+        // Add three test authorities
+        for i in 0..3 {
+            let keypair = ed25519::Keypair::generate();
+            let public_key = identity::PublicKey::from(keypair.public());
+            let peer_id = PeerId::from_public_key(&public_key);
+            
+            let authority = AuthorityInfo {
+                authority_id: peer_id,
+                authority_pubkey: hex::encode(keypair.public().to_bytes()),
+                primary_address: ("127.0.0.1".to_string(), format!("800{}", i)),
+                stake: 1,
+                workers_addresses: vec![("127.0.0.1".to_string(), format!("900{}", i))],
+            };
+            authorities.push(authority);
+        }
+        
+        Committee { authorities }
     }
 }
 

--- a/src/synchronizer/mod.rs
+++ b/src/synchronizer/mod.rs
@@ -210,3 +210,9 @@ pub enum FetchError {
     #[error("id error")]
     IdError,
 }
+
+#[cfg(test)]
+mod tests {
+    mod synchronizer_tests;
+    mod fetcher_tests;
+}

--- a/src/synchronizer/mod.rs
+++ b/src/synchronizer/mod.rs
@@ -213,6 +213,6 @@ pub enum FetchError {
 
 #[cfg(test)]
 mod tests {
-    mod synchronizer_tests;
     mod fetcher_tests;
+    mod synchronizer_tests;
 }

--- a/src/synchronizer/tests/fetcher_tests.rs
+++ b/src/synchronizer/tests/fetcher_tests.rs
@@ -22,6 +22,7 @@ use crate::{
 use async_trait::async_trait;
 use libp2p::PeerId;
 
+// Mock connector that allows testing network-related logic without real network dependencies
 #[derive(Clone)]
 struct MockConnector;
 
@@ -39,7 +40,7 @@ impl Connect for Arc<MockConnector> {
     }
 }
 
-// Create a mock connector that sleeps to simulate network delay
+// Mock connector that sleeps to simulate network delay
 #[derive(Clone)]
 struct SlowMockConnector;
 

--- a/src/synchronizer/tests/fetcher_tests.rs
+++ b/src/synchronizer/tests/fetcher_tests.rs
@@ -1,0 +1,216 @@
+use std::collections::HashSet;
+use tokio::sync::{broadcast, mpsc};
+
+use crate::{
+    synchronizer::{
+        fetcher::Fetcher,
+        traits::{DataProvider, Fetch},
+        FetchError, RequestedObject,
+    },
+    types::{
+        network::{NetworkRequest, ReceivedObject, RequestPayload, SyncRequest, SyncResponse},
+        traits::{AsBytes, Hash},
+    },
+};
+
+#[derive(Clone, Debug)]
+struct TestFetchable {
+    id: String,
+    data: Vec<u8>,
+}
+
+impl Hash for TestFetchable {
+    fn hash(&self) -> String {
+        self.id.clone()
+    }
+}
+
+impl AsBytes for TestFetchable {
+    fn bytes(&self) -> Vec<u8> {
+        self.data.clone()
+    }
+}
+
+struct TestDataProvider {
+    peers: Vec<String>,
+}
+
+impl DataProvider for TestDataProvider {
+    fn peers(&self) -> Vec<String> {
+        self.peers.clone()
+    }
+}
+
+#[tokio::test]
+async fn test_fetcher_empty() {
+    let (requests_tx, _) = mpsc::channel(100);
+    let (_, responses_rx) = broadcast::channel(100);
+    
+    let mut fetcher = Fetcher::new();
+    let result = fetcher.run(requests_tx, responses_rx).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_fetcher_single_request() {
+    let (requests_tx, mut requests_rx) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    let test_data = TestFetchable {
+        id: "test1".to_string(),
+        data: vec![1, 2, 3],
+    };
+    
+    let provider = Box::new(TestDataProvider {
+        peers: vec!["peer1".to_string()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: test_data.clone(),
+        source: provider,
+    };
+    
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // verify request is sent
+    let request = requests_rx.recv().await.unwrap();
+    match request {
+        NetworkRequest::Sync { request, peer_id } => {
+            assert_eq!(peer_id, "peer1");
+        }
+        _ => panic!("Expected sync request"),
+    }
+    
+    // send response
+    let response = SyncResponse::Success(RequestPayload::Data(test_data.bytes()));
+    let received = ReceivedObject {
+        object: response,
+        peer_id: "peer1".to_string(),
+    };
+    responses_tx.send(received).unwrap();
+    
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_fetcher_timeout() {
+    let (requests_tx, _) = mpsc::channel(100);
+    let (_, responses_rx) = broadcast::channel(100);
+    
+    let test_data = TestFetchable {
+        id: "test1".to_string(),
+        data: vec![1, 2, 3],
+    };
+    
+    let provider = Box::new(TestDataProvider {
+        peers: vec!["peer1".to_string()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: test_data,
+        source: provider,
+    };
+    
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object));
+    
+    // Run fetcher with very short timeout
+    tokio::time::timeout(
+        tokio::time::Duration::from_millis(50),
+        fetcher.run(requests_tx, responses_rx)
+    ).await.unwrap_err();
+}
+
+#[tokio::test]
+async fn test_fetcher_error_response() {
+    let (requests_tx, _) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    let test_data = TestFetchable {
+        id: "test1".to_string(),
+        data: vec![1, 2, 3],
+    };
+    
+    let provider = Box::new(TestDataProvider {
+        peers: vec!["peer1".to_string()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: test_data,
+        source: provider,
+    };
+    
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // send error response
+    let response = SyncResponse::Error("test error".to_string());
+    let received = ReceivedObject {
+        object: response,
+        peer_id: "peer1".to_string(),
+    };
+    responses_tx.send(received).unwrap();
+    
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_fetcher_multiple_peers() {
+    let (requests_tx, mut requests_rx) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    let test_data = TestFetchable {
+        id: "test1".to_string(),
+        data: vec![1, 2, 3],
+    };
+    
+    let provider = Box::new(TestDataProvider {
+        peers: vec!["peer1".to_string(), "peer2".to_string(), "peer3".to_string()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: test_data.clone(),
+        source: provider,
+    };
+    
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // verify first request is sent
+    let request = requests_rx.recv().await.unwrap();
+    match request {
+        NetworkRequest::Sync { request, peer_id } => {
+            assert!(["peer1", "peer2", "peer3"].contains(&peer_id.as_str()));
+        }
+        _ => panic!("Expected sync request"),
+    }
+    
+    // send successful response from one peer
+    let response = SyncResponse::Success(RequestPayload::Data(test_data.bytes()));
+    let received = ReceivedObject {
+        object: response,
+        peer_id: "peer2".to_string(),
+    };
+    responses_tx.send(received).unwrap();
+    
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    handle.abort();
+} 

--- a/src/synchronizer/tests/fetcher_tests.rs
+++ b/src/synchronizer/tests/fetcher_tests.rs
@@ -1,5 +1,4 @@
-use rand::random;
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 
@@ -7,7 +6,7 @@ use crate::{
     network::Connect,
     synchronizer::{
         fetcher::Fetcher,
-        traits::{DataProvider, Fetch, IntoSyncRequest},
+        traits::{DataProvider, IntoSyncRequest},
         RequestedObject,
     },
     types::{
@@ -17,7 +16,6 @@ use crate::{
         },
         traits::{AsBytes, Hash, Random},
         transaction::Transaction,
-        Digest,
     },
 };
 
@@ -231,7 +229,7 @@ async fn test_fetcher_single_request() {
 #[tokio::test]
 async fn test_fetcher_timeout() {
     let (requests_tx, _) = mpsc::channel(100);
-    let (responses_tx, mut responses_rx) = broadcast::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
     let (commands_tx, commands_rx) = mpsc::channel(100);
 
     let test_data = TestFetchable {
@@ -264,7 +262,7 @@ async fn test_fetcher_timeout() {
     drop(commands_tx);
 
     // Run fetcher with a longer timeout to ensure it has time to process
-    let result = tokio::time::timeout(tokio::time::Duration::from_millis(1000), handle).await;
+    let result = tokio::time::timeout(tokio::time::Duration::from_millis(100), handle).await;
 
     // The fetcher should complete successfully, but the fetch operation should have timed out
     assert!(result.is_ok(), "Fetcher should complete");
@@ -273,7 +271,7 @@ async fn test_fetcher_timeout() {
 #[tokio::test]
 async fn test_fetcher_error_response() {
     let (requests_tx, _) = mpsc::channel(100);
-    let (responses_tx, mut responses_rx) = broadcast::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
     let (commands_tx, commands_rx) = mpsc::channel(100);
 
     let test_data = TestFetchable {

--- a/src/synchronizer/tests/synchronizer_tests.rs
+++ b/src/synchronizer/tests/synchronizer_tests.rs
@@ -1,0 +1,403 @@
+use std::{collections::HashSet, sync::Arc};
+
+use tokio::sync::{broadcast, mpsc};
+
+use crate::{
+    synchronizer::{
+        fetcher::Fetcher,
+        traits::{DataProvider, Fetch},
+        RequestedObject,
+    },
+    types::{
+        network::{NetworkRequest, ReceivedObject, RequestPayload, SyncRequest, SyncResponse},
+        traits::{AsBytes, Hash},
+    },
+};
+
+#[derive(Clone, Debug)]
+struct MockData {
+    id: String,
+}
+
+impl Hash for MockData {
+    fn hash(&self) -> String {
+        self.id.clone()
+    }
+}
+
+impl AsBytes for MockData {
+    fn bytes(&self) -> Vec<u8> {
+        self.id.as_bytes().to_vec()
+    }
+}
+
+struct MockDataProvider {
+    peers: Vec<String>,
+}
+
+impl DataProvider for MockDataProvider {
+    fn peers(&self) -> Vec<String> {
+        self.peers.clone()
+    }
+}
+
+#[tokio::test]
+async fn test_fetcher_basic() {
+    let (requests_tx, mut requests_rx) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    // create mock data and provider
+    let mock_data = MockData {
+        id: "test_data".to_string(),
+    };
+    let mock_provider = Box::new(MockDataProvider {
+        peers: vec!["peer1".to_string(), "peer2".to_string()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: mock_data,
+        source: mock_provider,
+    };
+    
+    // create and start fetcher
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // verify request is sent
+    let request = requests_rx.recv().await.unwrap();
+    match request {
+        NetworkRequest::Sync { request, peer_id } => {
+            assert!(peer_id == "peer1" || peer_id == "peer2");
+        }
+        _ => panic!("Expected sync request"),
+    }
+    
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_fetcher_response_handling() {
+    let (requests_tx, _) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    // create mock data and provider
+    let mock_data = MockData {
+        id: "test_data".to_string(),
+    };
+    let mock_provider = Box::new(MockDataProvider {
+        peers: vec!["peer1".to_string()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: mock_data.clone(),
+        source: mock_provider,
+    };
+    
+    // create and start fetcher
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // send mock response
+    let response = SyncResponse::Success(RequestPayload::Data(mock_data.bytes()));
+    let received_response = ReceivedObject {
+        object: response,
+        peer_id: "peer1".to_string(),
+    };
+    responses_tx.send(received_response).unwrap();
+    
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_fetcher_multiple_objects() {
+    let (requests_tx, mut requests_rx) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    let mock_data1 = MockData {
+        id: "test_data1".to_string(),
+    };
+    let mock_data2 = MockData {
+        id: "test_data2".to_string(),
+    };
+    
+    let mock_provider = Box::new(MockDataProvider {
+        peers: vec!["peer1".to_string()],
+    });
+    
+    let requested_object1 = RequestedObject {
+        object: mock_data1,
+        source: mock_provider.clone(),
+    };
+    let requested_object2 = RequestedObject {
+        object: mock_data2,
+        source: mock_provider,
+    };
+    
+    // create and start fetcher
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object1));
+    fetcher.push(Box::new(requested_object2));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // verify multiple requests are sent
+    let request1 = requests_rx.recv().await.unwrap();
+    let request2 = requests_rx.recv().await.unwrap();
+    
+    assert!(matches!(request1, NetworkRequest::Sync { .. }));
+    assert!(matches!(request2, NetworkRequest::Sync { .. }));
+    
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_synchronizer_concurrent_requests() {
+    let (requests_tx, mut requests_rx) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    // create multiple mock objects with different providers
+    let mock_data1 = MockData {
+        id: "data1".to_string(),
+    };
+    let mock_data2 = MockData {
+        id: "data2".to_string(),
+    };
+    let mock_data3 = MockData {
+        id: "data3".to_string(),
+    };
+    
+    let provider1 = Box::new(MockDataProvider {
+        peers: vec!["peer1".to_string()],
+    });
+    let provider2 = Box::new(MockDataProvider {
+        peers: vec!["peer2".to_string()],
+    });
+    let provider3 = Box::new(MockDataProvider {
+        peers: vec!["peer3".to_string()],
+    });
+    
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(RequestedObject {
+        object: mock_data1.clone(),
+        source: provider1,
+    }));
+    fetcher.push(Box::new(RequestedObject {
+        object: mock_data2.clone(),
+        source: provider2,
+    }));
+    fetcher.push(Box::new(RequestedObject {
+        object: mock_data3.clone(),
+        source: provider3,
+    }));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // collect all requests
+    let mut received_requests = HashSet::new();
+    for _ in 0..3 {
+        if let NetworkRequest::Sync { request: _, peer_id } = requests_rx.recv().await.unwrap() {
+            received_requests.insert(peer_id);
+        }
+    }
+    
+    assert_eq!(received_requests.len(), 3);
+    assert!(received_requests.contains("peer1"));
+    assert!(received_requests.contains("peer2"));
+    assert!(received_requests.contains("peer3"));
+    
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_synchronizer_retry_on_failure() {
+    let (requests_tx, mut requests_rx) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    let mock_data = MockData {
+        id: "test_data".to_string(),
+    };
+    
+    let provider = Box::new(MockDataProvider {
+        peers: vec!["peer1".to_string(), "peer2".to_string()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: mock_data.clone(),
+        source: provider,
+    };
+    
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // get first request
+    let request1 = requests_rx.recv().await.unwrap();
+    match request1 {
+        NetworkRequest::Sync { request: _, peer_id } => {
+            // send error response
+            let error_response = SyncResponse::Error("test error".to_string());
+            responses_tx
+                .send(ReceivedObject {
+                    object: error_response,
+                    peer_id: peer_id.clone(),
+                })
+                .unwrap();
+        }
+        _ => panic!("Expected sync request"),
+    }
+    
+    // should get another request to different peer
+    let request2 = requests_rx.recv().await.unwrap();
+    match request2 {
+        NetworkRequest::Sync { request: _, peer_id } => {
+            assert_ne!(
+                peer_id,
+                match request1 {
+                    NetworkRequest::Sync { peer_id, .. } => peer_id,
+                    _ => panic!("Expected sync request"),
+                }
+            );
+        }
+        _ => panic!("Expected sync request"),
+    }
+    
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_synchronizer_partial_response() {
+    let (requests_tx, mut requests_rx) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    let mock_data1 = MockData {
+        id: "data1".to_string(),
+    };
+    let mock_data2 = MockData {
+        id: "data2".to_string(),
+    };
+    
+    let provider = Box::new(MockDataProvider {
+        peers: vec!["peer1".to_string()],
+    });
+    
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(RequestedObject {
+        object: mock_data1.clone(),
+        source: provider.clone(),
+    }));
+    fetcher.push(Box::new(RequestedObject {
+        object: mock_data2.clone(),
+        source: provider,
+    }));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // get first request
+    let request = requests_rx.recv().await.unwrap();
+    match request {
+        NetworkRequest::Sync { request: _, peer_id } => {
+            // Send partial success response
+            let response = SyncResponse::Success(RequestPayload::Data(mock_data1.bytes()));
+            responses_tx
+                .send(ReceivedObject {
+                    object: response,
+                    peer_id,
+                })
+                .unwrap();
+        }
+        _ => panic!("Expected sync request"),
+    }
+    
+    // Should get another request for remaining data
+    let request = requests_rx.recv().await.unwrap();
+    match request {
+        NetworkRequest::Sync { request: _, peer_id } => {
+            // Send success response for second object
+            let response = SyncResponse::Success(RequestPayload::Data(mock_data2.bytes()));
+            responses_tx
+                .send(ReceivedObject {
+                    object: response,
+                    peer_id,
+                })
+                .unwrap();
+        }
+        _ => panic!("Expected sync request"),
+    }
+    
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_synchronizer_invalid_response_data() {
+    let (requests_tx, mut requests_rx) = mpsc::channel(100);
+    let (responses_tx, responses_rx) = broadcast::channel(100);
+    
+    let mock_data = MockData {
+        id: "test_data".to_string(),
+    };
+    
+    let provider = Box::new(MockDataProvider {
+        peers: vec!["peer1".to_string(), "peer2".to_string()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: mock_data.clone(),
+        source: provider,
+    };
+    
+    let mut fetcher = Fetcher::new();
+    fetcher.push(Box::new(requested_object));
+    
+    // run fetcher
+    let handle = tokio::spawn(async move {
+        fetcher.run(requests_tx, responses_rx).await.unwrap();
+    });
+    
+    // get request
+    let request = requests_rx.recv().await.unwrap();
+    match request {
+        NetworkRequest::Sync { request: _, peer_id } => {
+            // Send invalid response data
+            let invalid_data = vec![0, 1, 2]; // Different from what was requested
+            let response = SyncResponse::Success(RequestPayload::Data(invalid_data));
+            responses_tx
+                .send(ReceivedObject {
+                    object: response,
+                    peer_id,
+                })
+                .unwrap();
+        }
+        _ => panic!("Expected sync request"),
+    }
+    
+    // should get another request due to invalid response
+    let request = requests_rx.recv().await.unwrap();
+    assert!(matches!(request, NetworkRequest::Sync { .. }));
+    
+    handle.abort();
+} 

--- a/src/synchronizer/tests/synchronizer_tests.rs
+++ b/src/synchronizer/tests/synchronizer_tests.rs
@@ -1,60 +1,211 @@
-use std::{collections::HashSet, sync::Arc};
-
-use tokio::sync::{broadcast, mpsc};
-
 use crate::{
+    network::Connect,
     synchronizer::{
         fetcher::Fetcher,
-        traits::{DataProvider, Fetch},
+        traits::{DataProvider, IntoSyncRequest},
         RequestedObject,
     },
     types::{
-        network::{NetworkRequest, ReceivedObject, RequestPayload, SyncRequest, SyncResponse},
-        traits::{AsBytes, Hash},
+        batch::{Batch, BatchId},
+        network::{NetworkRequest, ReceivedObject, RequestPayload, SyncData, SyncRequest, SyncResponse},
+        traits::{AsBytes, Hash, Random},
+        transaction::Transaction,
+        Digest,
     },
 };
+use async_trait::async_trait;
+use libp2p::PeerId;
+use std::{collections::HashSet, sync::Arc};
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
 
-#[derive(Clone, Debug)]
-struct MockData {
-    id: String,
+struct MockConnector;
+
+#[async_trait]
+impl Connect for MockConnector {
+    async fn dispatch(&self, _request: &RequestPayload, _peer_id: PeerId) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
-impl Hash for MockData {
-    fn hash(&self) -> String {
-        self.id.clone()
+#[async_trait]
+impl Connect for Arc<MockConnector> {
+    async fn dispatch(&self, request: &RequestPayload, peer_id: PeerId) -> anyhow::Result<()> {
+        self.as_ref().dispatch(request, peer_id).await
     }
+}
+
+#[derive(Clone)]
+struct MockData {
+    data: Vec<u8>,
 }
 
 impl AsBytes for MockData {
     fn bytes(&self) -> Vec<u8> {
-        self.id.as_bytes().to_vec()
+        self.data.clone()
     }
 }
 
-struct MockDataProvider {
-    peers: Vec<String>,
+impl IntoSyncRequest for MockData {
+    fn into_sync_request(&self) -> SyncRequest {
+        let digest = blake3::hash(&self.bytes()).into();
+        SyncRequest::Batches(vec![digest])
+    }
 }
 
+#[derive(Clone)]
+struct MockDataProvider {
+    peers: Vec<PeerId>,
+}
+
+#[async_trait]
 impl DataProvider for MockDataProvider {
-    fn peers(&self) -> Vec<String> {
-        self.peers.clone()
+    async fn sources(&self) -> Box<dyn Iterator<Item = PeerId> + Send> {
+        Box::new(self.peers.clone().into_iter())
     }
 }
 
 #[tokio::test]
+async fn test_synchronizer_invalid_response_data() {
+    let (network_tx, mut network_rx) = mpsc::channel(100);
+    let (commands_tx, commands_rx) = mpsc::channel(100);
+    let (sync_tx, sync_rx) = broadcast::channel(100);
+    
+    let mock_data = MockData {
+        data: vec![1, 2, 3],
+    };
+    
+    let peer_id = PeerId::random();
+    let provider = Box::new(MockDataProvider {
+        peers: vec![peer_id],
+    });
+    
+    let requested_object = RequestedObject {
+        object: mock_data.clone(),
+        source: provider,
+    };
+    
+    let _handle = Fetcher::spawn(
+        CancellationToken::new(),
+        network_tx,
+        commands_rx,
+        sync_rx,
+        Arc::new(MockConnector),
+        10,
+    );
+    
+    // Send the request through the commands channel
+    let request = Box::new(requested_object);
+    commands_tx.send(request).await.unwrap();
+    
+    // Drop commands_tx to signal no more commands
+    drop(commands_tx);
+    
+    // verify request is sent
+    let request = network_rx.recv().await.unwrap();
+    match request {
+        NetworkRequest::SendTo(pid, RequestPayload::SyncRequest(sync_req)) => {
+            assert_eq!(pid, peer_id);
+            let expected_digest = blake3::hash(&mock_data.bytes()).into();
+            assert_eq!(sync_req, SyncRequest::Batches(vec![expected_digest]));
+            
+            // Send successful response
+            let tx = Transaction::random(32);
+            let batch = Batch::new(vec![tx]);
+            let sync_data = SyncData::Batches(vec![batch]);
+            let request_id = mock_data.into_sync_request().digest();
+            let response = SyncResponse::Success(request_id, sync_data);
+            let received = ReceivedObject {
+                object: response,
+                sender: pid,
+            };
+            sync_tx.send(received).unwrap();
+        }
+        _ => panic!("Expected SendTo request with SyncRequest payload"),
+    };
+    
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+}
+
+#[tokio::test]
+async fn test_synchronizer_multiple_peers() {
+    let (network_tx, mut network_rx) = mpsc::channel(100);
+    let (commands_tx, commands_rx) = mpsc::channel(100);
+    let (sync_tx, sync_rx) = broadcast::channel(100);
+    
+    let mock_data = MockData {
+        data: vec![1, 2, 3],
+    };
+    
+    let provider = Box::new(MockDataProvider {
+        peers: vec![PeerId::random(), PeerId::random(), PeerId::random()],
+    });
+    
+    let requested_object = RequestedObject {
+        object: mock_data.clone(),
+        source: provider.clone(),
+    };
+    
+    let _handle = Fetcher::spawn(
+        CancellationToken::new(),
+        network_tx,
+        commands_rx,
+        sync_rx,
+        Arc::new(MockConnector),
+        10,
+    );
+    
+    // Send the request through the commands channel
+    let request = Box::new(requested_object);
+    commands_tx.send(request).await.unwrap();
+    
+    // Drop commands_tx to signal no more commands
+    drop(commands_tx);
+    
+    // verify first request is sent
+    let request = network_rx.recv().await.unwrap();
+    let matched_peer_id = match request {
+        NetworkRequest::SendTo(pid, RequestPayload::SyncRequest(sync_req)) => {
+            let mut peer_ids = provider.sources().await;
+            let expected_peer = peer_ids.next().unwrap();
+            assert_eq!(pid, expected_peer);
+            let expected_digest = blake3::hash(&mock_data.bytes()).into();
+            assert_eq!(sync_req, SyncRequest::Batches(vec![expected_digest]));
+            pid
+        }
+        _ => panic!("Expected SendTo request with SyncRequest payload"),
+    };
+    
+    // Send successful response
+    let tx = Transaction::random(32);
+    let batch = Batch::new(vec![tx]);
+    let sync_data = SyncData::Batches(vec![batch]);
+    let request_id = mock_data.into_sync_request().digest();
+    let response = SyncResponse::Success(request_id, sync_data);
+    let received = ReceivedObject {
+        object: response,
+        sender: matched_peer_id,
+    };
+    sync_tx.send(received).unwrap();
+    
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+}
+
+#[tokio::test]
 async fn test_fetcher_multiple_objects() {
-    let (requests_tx, mut requests_rx) = mpsc::channel(100);
-    let (responses_tx, responses_rx) = broadcast::channel(100);
+    let (network_tx, mut network_rx) = mpsc::channel(100);
+    let (commands_tx, commands_rx) = mpsc::channel(100);
+    let (sync_tx, sync_rx) = broadcast::channel(100);
     
     let mock_data1 = MockData {
-        id: "test_data1".to_string(),
+        data: vec![1, 2, 3],
     };
     let mock_data2 = MockData {
-        id: "test_data2".to_string(),
+        data: vec![4, 5, 6],
     };
     
     let mock_provider = Box::new(MockDataProvider {
-        peers: vec!["peer1".to_string()],
+        peers: vec![PeerId::random(), PeerId::random(), PeerId::random()],
     });
     
     let requested_object1 = RequestedObject {
@@ -66,92 +217,104 @@ async fn test_fetcher_multiple_objects() {
         source: mock_provider,
     };
     
-    let mut fetcher = Fetcher::new();
-    fetcher.push(Box::new(requested_object1));
-    fetcher.push(Box::new(requested_object2));
+    let _handle = Fetcher::spawn(
+        CancellationToken::new(),
+        network_tx,
+        commands_rx,
+        sync_rx,
+        Arc::new(MockConnector),
+        10,
+    );
+
+    // Send requests through the commands channel
+    commands_tx.send(Box::new(requested_object1)).await.unwrap();
+    commands_tx.send(Box::new(requested_object2)).await.unwrap();
     
-    let handle = tokio::spawn(async move {
-        fetcher.run(requests_tx, responses_rx).await.unwrap();
-    });
+    // Drop commands_tx to signal no more commands
+    drop(commands_tx);
     
-    let request1 = requests_rx.recv().await.unwrap();
-    let request2 = requests_rx.recv().await.unwrap();
+    // Verify requests are sent
+    let request1 = network_rx.recv().await.unwrap();
+    let request2 = network_rx.recv().await.unwrap();
     
-    assert!(matches!(request1, NetworkRequest::Sync { .. }));
-    assert!(matches!(request2, NetworkRequest::Sync { .. }));
-    
-    handle.abort();
+    assert!(matches!(request1, NetworkRequest::SendTo(_, _)));
+    assert!(matches!(request2, NetworkRequest::SendTo(_, _)));
 }
 
 #[tokio::test]
 async fn test_synchronizer_concurrent_requests() {
-    let (requests_tx, mut requests_rx) = mpsc::channel(100);
-    let (responses_tx, responses_rx) = broadcast::channel(100);
+    let (network_tx, mut network_rx) = mpsc::channel(100);
+    let (commands_tx, commands_rx) = mpsc::channel(100);
+    let (sync_tx, sync_rx) = broadcast::channel(100);
     
     let mock_data1 = MockData {
-        id: "data1".to_string(),
+        data: vec![1, 2, 3],
     };
     let mock_data2 = MockData {
-        id: "data2".to_string(),
+        data: vec![4, 5, 6],
     };
     let mock_data3 = MockData {
-        id: "data3".to_string(),
+        data: vec![7, 8, 9],
     };
     
     let provider1 = Box::new(MockDataProvider {
-        peers: vec!["peer1".to_string()],
+        peers: vec![PeerId::random(), PeerId::random(), PeerId::random()],
     });
     let provider2 = Box::new(MockDataProvider {
-        peers: vec!["peer2".to_string()],
+        peers: vec![PeerId::random(), PeerId::random(), PeerId::random()],
     });
     let provider3 = Box::new(MockDataProvider {
-        peers: vec!["peer3".to_string()],
+        peers: vec![PeerId::random(), PeerId::random(), PeerId::random()],
     });
     
-    let mut fetcher = Fetcher::new();
-    fetcher.push(Box::new(RequestedObject {
+    let _handle = Fetcher::spawn(
+        CancellationToken::new(),
+        network_tx,
+        commands_rx,
+        sync_rx,
+        Arc::new(MockConnector),
+        10,
+    );
+
+    // Send requests through the commands channel
+    commands_tx.send(Box::new(RequestedObject {
         object: mock_data1.clone(),
         source: provider1,
-    }));
-    fetcher.push(Box::new(RequestedObject {
+    })).await.unwrap();
+    commands_tx.send(Box::new(RequestedObject {
         object: mock_data2.clone(),
         source: provider2,
-    }));
-    fetcher.push(Box::new(RequestedObject {
+    })).await.unwrap();
+    commands_tx.send(Box::new(RequestedObject {
         object: mock_data3.clone(),
         source: provider3,
-    }));
+    })).await.unwrap();
     
-    let handle = tokio::spawn(async move {
-        fetcher.run(requests_tx, responses_rx).await.unwrap();
-    });
+    // Drop commands_tx to signal no more commands
+    drop(commands_tx);
     
     let mut received_requests = HashSet::new();
     for _ in 0..3 {
-        if let NetworkRequest::Sync { request: _, peer_id } = requests_rx.recv().await.unwrap() {
+        if let NetworkRequest::SendTo(peer_id, _) = network_rx.recv().await.unwrap() {
             received_requests.insert(peer_id);
         }
     }
     
     assert_eq!(received_requests.len(), 3);
-    assert!(received_requests.contains("peer1"));
-    assert!(received_requests.contains("peer2"));
-    assert!(received_requests.contains("peer3"));
-    
-    handle.abort();
 }
 
 #[tokio::test]
 async fn test_synchronizer_retry_on_failure() {
-    let (requests_tx, mut requests_rx) = mpsc::channel(100);
-    let (responses_tx, responses_rx) = broadcast::channel(100);
+    let (network_tx, mut network_rx) = mpsc::channel(100);
+    let (commands_tx, commands_rx) = mpsc::channel(100);
+    let (sync_tx, sync_rx) = broadcast::channel(100);
     
     let mock_data = MockData {
-        id: "test_data".to_string(),
+        data: vec![1, 2, 3],
     };
     
     let provider = Box::new(MockDataProvider {
-        peers: vec!["peer1".to_string(), "peer2".to_string()],
+        peers: vec![PeerId::random(), PeerId::random()],
     });
     
     let requested_object = RequestedObject {
@@ -159,86 +322,41 @@ async fn test_synchronizer_retry_on_failure() {
         source: provider,
     };
     
-    let mut fetcher = Fetcher::new();
-    fetcher.push(Box::new(requested_object));
-    
-    let handle = tokio::spawn(async move {
-        fetcher.run(requests_tx, responses_rx).await.unwrap();
-    });
-    
-    let request1 = requests_rx.recv().await.unwrap();
-    match request1 {
-        NetworkRequest::Sync { request: _, peer_id } => {
-            let error_response = SyncResponse::Error("test error".to_string());
-            responses_tx
-                .send(ReceivedObject {
-                    object: error_response,
-                    peer_id: peer_id.clone(),
-                })
-                .unwrap();
-        }
-        _ => panic!("Expected sync request"),
-    }
-    
-    let request2 = requests_rx.recv().await.unwrap();
-    match request2 {
-        NetworkRequest::Sync { request: _, peer_id } => {
-            assert_ne!(
-                peer_id,
-                match request1 {
-                    NetworkRequest::Sync { peer_id, .. } => peer_id,
-                    _ => panic!("Expected sync request"),
-                }
-            );
-        }
-        _ => panic!("Expected sync request"),
-    }
-    
-    handle.abort();
-}
+    let _handle = Fetcher::spawn(
+        CancellationToken::new(),
+        network_tx,
+        commands_rx,
+        sync_rx,
+        Arc::new(MockConnector),
+        10,
+    );
 
-#[tokio::test]
-async fn test_synchronizer_invalid_response_data() {
-    let (requests_tx, mut requests_rx) = mpsc::channel(100);
-    let (responses_tx, responses_rx) = broadcast::channel(100);
+    // Send request through the commands channel
+    commands_tx.send(Box::new(requested_object)).await.unwrap();
     
-    let mock_data = MockData {
-        id: "test_data".to_string(),
-    };
+    // Drop commands_tx to signal no more commands
+    drop(commands_tx);
     
-    let provider = Box::new(MockDataProvider {
-        peers: vec!["peer1".to_string(), "peer2".to_string()],
-    });
-    
-    let requested_object = RequestedObject {
-        object: mock_data.clone(),
-        source: provider,
-    };
-    
-    let mut fetcher = Fetcher::new();
-    fetcher.push(Box::new(requested_object));
-    
-    let handle = tokio::spawn(async move {
-        fetcher.run(requests_tx, responses_rx).await.unwrap();
-    });
-    
-    let request = requests_rx.recv().await.unwrap();
-    match request {
-        NetworkRequest::Sync { request: _, peer_id } => {
-            let invalid_data = vec![0, 1, 2]; // Different from what was requested
-            let response = SyncResponse::Success(RequestPayload::Data(invalid_data));
-            responses_tx
-                .send(ReceivedObject {
-                    object: response,
-                    peer_id,
-                })
-                .unwrap();
+    let request1 = network_rx.recv().await.unwrap();
+    match request1 {
+        NetworkRequest::SendTo(peer_id, _) => {
+            let response = SyncResponse::Failure(mock_data.into_sync_request().digest());
+            sync_tx.send(ReceivedObject {
+                object: response,
+                sender: peer_id,
+            }).unwrap();
         }
-        _ => panic!("Expected sync request"),
+        _ => panic!("Expected SendTo request"),
     }
     
-    let request = requests_rx.recv().await.unwrap();
-    assert!(matches!(request, NetworkRequest::Sync { .. }));
-    
-    handle.abort();
+    let request2 = network_rx.recv().await.unwrap();
+    match request2 {
+        NetworkRequest::SendTo(peer_id1, _) => {
+            match request1 {
+                NetworkRequest::SendTo(peer_id2, _) => assert_ne!(peer_id1, peer_id2),
+                _ => panic!("Expected SendTo request"),
+            }
+        }
+        _ => panic!("Expected SendTo request"),
+    }
 } 

--- a/src/synchronizer/tests/synchronizer_tests.rs
+++ b/src/synchronizer/tests/synchronizer_tests.rs
@@ -75,9 +75,11 @@ async fn test_synchronizer_invalid_response_data() {
         data: vec![1, 2, 3],
     };
     
+    // Create multiple peers for retry mechanism
     let peer_id = PeerId::random();
+    let peer_id2 = PeerId::random();
     let provider = Box::new(MockDataProvider {
-        peers: vec![peer_id],
+        peers: vec![peer_id, peer_id2],
     });
     
     let requested_object = RequestedObject {
@@ -85,8 +87,9 @@ async fn test_synchronizer_invalid_response_data() {
         source: provider,
     };
     
-    let _handle = Fetcher::spawn(
-        CancellationToken::new(),
+    let token = CancellationToken::new();
+    let handle = Fetcher::spawn(
+        token.clone(),
         network_tx,
         commands_rx,
         sync_rx,
@@ -98,33 +101,76 @@ async fn test_synchronizer_invalid_response_data() {
     let request = Box::new(requested_object);
     commands_tx.send(request).await.unwrap();
     
-    // Drop commands_tx to signal no more commands
-    drop(commands_tx);
-    
-    // verify request is sent
-    let request = network_rx.recv().await.unwrap();
-    match request {
+    // Verify initial request is sent with timeout
+    let initial_request = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        network_rx.recv()
+    ).await.expect("Timed out waiting for initial request")
+    .expect("Channel closed unexpectedly");
+
+    match initial_request {
         NetworkRequest::SendTo(pid, RequestPayload::SyncRequest(sync_req)) => {
             assert_eq!(pid, peer_id);
             let expected_digest = blake3::hash(&mock_data.bytes()).into();
             assert_eq!(sync_req, SyncRequest::Batches(vec![expected_digest]));
             
-            // Send successful response
+            // Send invalid response - completely different batch with different digest
+            let different_data = MockData {
+                data: vec![4, 5, 6], // Different data
+            };
+            let tx = Transaction::random(32);
+            let invalid_batch = Batch::new(vec![tx]);
+            let sync_data = SyncData::Batches(vec![invalid_batch]);
+            
+            // Use the digest from the different data to ensure mismatch
+            let request_id = different_data.into_sync_request().digest();
+            let response = SyncResponse::Success(request_id, sync_data);
+            
+            // Send the invalid response
+            sync_tx.send(ReceivedObject {
+                object: response,
+                sender: pid,
+            }).unwrap();
+        }
+        _ => panic!("Expected initial SendTo request with SyncRequest payload"),
+    }
+
+    // Give some time for the invalid response to be processed
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Verify retry request is sent with timeout
+    let retry_request = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        network_rx.recv()
+    ).await.expect("Timed out waiting for retry request")
+    .expect("Channel closed unexpectedly");
+
+    match retry_request {
+        NetworkRequest::SendTo(pid, RequestPayload::SyncRequest(_)) => {
+            assert_eq!(pid, peer_id2, "Retry should use the second peer");
+            
+            // Send valid response from second peer to complete the test
             let tx = Transaction::random(32);
             let batch = Batch::new(vec![tx]);
             let sync_data = SyncData::Batches(vec![batch]);
             let request_id = mock_data.into_sync_request().digest();
             let response = SyncResponse::Success(request_id, sync_data);
-            let received = ReceivedObject {
+            sync_tx.send(ReceivedObject {
                 object: response,
-                sender: pid,
-            };
-            sync_tx.send(received).unwrap();
+                sender: peer_id2,
+            }).unwrap();
         }
-        _ => panic!("Expected SendTo request with SyncRequest payload"),
-    };
-    
+        _ => panic!("Expected retry request with SyncRequest payload"),
+    }
+
+    // Verify no more requests are sent
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    assert!(network_rx.try_recv().is_err(), "No more requests should be sent after successful response");
+    
+    // Clean shutdown
+    drop(commands_tx);
+    token.cancel();
+    let _ = handle.await;
 }
 
 #[tokio::test]

--- a/src/types/dag.rs
+++ b/src/types/dag.rs
@@ -57,14 +57,14 @@ where
     }
     /// Check if a vertex has all its parents in the DAG, returning an error containing the missing parents if not.
     pub fn check_parents(&self, vertex: &Vertex<T>) -> Result<(), DagError> {
-        // Base layer (0) and layer 1 vertices don't require parents
-        if vertex.layer <= self.base_layer || vertex.layer == 1 {
+        // Only base layer vertices can be parentless
+        if vertex.layer == self.base_layer {
             if vertex.parents.is_empty() {
                 return Ok(());
             }
         }
 
-        // For other layers, check if all parents exist in any previous layer
+        // All other vertices must have valid parents in previous layers
         let found_parents: HashSet<_> = (self.base_layer..vertex.layer)
             .rev()
             .flat_map(|layer| self.vertices_by_layers.get(&layer).into_iter().flatten())

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -43,3 +43,8 @@ impl AsBytes for Acknowledgment {
         self.0.to_vec()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    mod dag_tests;
+}

--- a/src/types/tests/dag_tests.rs
+++ b/src/types/tests/dag_tests.rs
@@ -3,17 +3,12 @@ use std::collections::HashSet;
 use crate::types::{
     dag::{Dag, DagError, Vertex},
     traits::{AsBytes, Hash},
+    Digest,
 };
 
 #[derive(Clone, Debug)]
 struct TestData {
     value: u64,
-}
-
-impl Hash for TestData {
-    fn hash(&self) -> String {
-        format!("test_data_{}", self.value)
-    }
 }
 
 impl AsBytes for TestData {
@@ -24,7 +19,7 @@ impl AsBytes for TestData {
 
 #[tokio::test]
 async fn test_dag_creation_and_basic_ops() {
-    let base_layer = 0;
+    let base_layer: u64 = 0;
     let mut dag: Dag<TestData> = Dag::new(base_layer);
     
     // Test initial state
@@ -42,9 +37,9 @@ async fn test_dag_creation_and_basic_ops() {
     assert_eq!(dag.layer_size(1), 1);
     
     // Test vertex retrieval
-    let retrieved = dag.get_vertex(&vertex_id).unwrap();
+    let retrieved = dag.get(&vertex_id).unwrap();
     assert_eq!(retrieved.data().value, 1);
-    assert_eq!(retrieved.layer(), 1);
+    assert_eq!(*retrieved.layer(), 1);
 }
 
 #[tokio::test]

--- a/src/types/tests/dag_tests.rs
+++ b/src/types/tests/dag_tests.rs
@@ -21,21 +21,21 @@ impl AsBytes for TestData {
 async fn test_dag_creation_and_basic_ops() {
     let base_layer: u64 = 0;
     let mut dag: Dag<TestData> = Dag::new(base_layer);
-    
+
     // Test initial state
     assert_eq!(dag.height(), base_layer);
     assert_eq!(dag.base_layer(), base_layer);
-    
+
     // Test vertex insertion
     let data = TestData { value: 1 };
     let parents = HashSet::new();
     let vertex = Vertex::from_data(data, 1, parents);
     let vertex_id = vertex.id().clone();
-    
+
     dag.insert(vertex).unwrap();
     assert_eq!(dag.height(), 1);
     assert_eq!(dag.layer_size(1), 1);
-    
+
     // Test vertex retrieval
     let retrieved = dag.get(&vertex_id).unwrap();
     assert_eq!(retrieved.data().value, 1);
@@ -45,31 +45,31 @@ async fn test_dag_creation_and_basic_ops() {
 #[tokio::test]
 async fn test_dag_parent_child_relationships() {
     let mut dag: Dag<TestData> = Dag::new(0);
-    
+
     // Create parent vertex
     let parent_data = TestData { value: 1 };
     let parent_vertex = Vertex::from_data(parent_data, 1, HashSet::new());
     let parent_id = parent_vertex.id().clone();
     dag.insert(parent_vertex).unwrap();
-    
+
     // Create child vertex with parent reference
     let mut parents = HashSet::new();
     parents.insert(parent_id);
     let child_data = TestData { value: 2 };
     let child_vertex = Vertex::from_data(child_data, 2, parents);
-    
+
     dag.insert_checked(child_vertex).unwrap();
 }
 
 #[tokio::test]
 async fn test_dag_invalid_parent() {
     let mut dag: Dag<TestData> = Dag::new(0);
-    
+
     let mut parents = HashSet::new();
     parents.insert("non_existent_parent".to_string());
     let data = TestData { value: 1 };
     let vertex = Vertex::from_data(data, 1, parents);
-    
+
     match dag.insert_checked(vertex) {
         Err(DagError::MissingParents(_)) => (),
         _ => panic!("Expected MissingParents error"),
@@ -79,19 +79,19 @@ async fn test_dag_invalid_parent() {
 #[tokio::test]
 async fn test_dag_layer_operations() {
     let mut dag: Dag<TestData> = Dag::new(0);
-    
+
     // Insert vertices in different layers
     for i in 1..=3 {
         let data = TestData { value: i };
         let vertex = Vertex::from_data(data, i as u64, HashSet::new());
         dag.insert(vertex).unwrap();
     }
-    
+
     // Test layer queries
     assert_eq!(dag.layer_size(1), 1);
     assert_eq!(dag.layer_size(2), 1);
     assert_eq!(dag.layer_size(3), 1);
-    
+
     let layer_2_vertices = dag.layer_vertices(2);
     assert_eq!(layer_2_vertices.len(), 1);
     assert_eq!(layer_2_vertices[0].data().value, 2);
@@ -100,27 +100,27 @@ async fn test_dag_layer_operations() {
 #[tokio::test]
 async fn test_dag_multiple_parents() {
     let mut dag: Dag<TestData> = Dag::new(0);
-    
+
     // Create two parent vertices
     let parent1_data = TestData { value: 1 };
     let parent2_data = TestData { value: 2 };
     let parent1_vertex = Vertex::from_data(parent1_data, 1, HashSet::new());
     let parent2_vertex = Vertex::from_data(parent2_data, 1, HashSet::new());
-    
+
     let parent1_id = parent1_vertex.id().clone();
     let parent2_id = parent2_vertex.id().clone();
-    
+
     dag.insert(parent1_vertex).unwrap();
     dag.insert(parent2_vertex).unwrap();
-    
+
     // Create child with multiple parents
     let mut parents = HashSet::new();
     parents.insert(parent1_id);
     parents.insert(parent2_id);
-    
+
     let child_data = TestData { value: 3 };
     let child_vertex = Vertex::from_data(child_data, 2, parents);
-    
+
     dag.insert_checked(child_vertex).unwrap();
     assert_eq!(dag.layer_size(2), 1);
 }
@@ -128,60 +128,60 @@ async fn test_dag_multiple_parents() {
 #[tokio::test]
 async fn test_dag_cyclic_insertion_prevention() {
     let mut dag: Dag<TestData> = Dag::new(0);
-    
+
     // Create first vertex
     let data1 = TestData { value: 1 };
     let vertex1 = Vertex::from_data(data1, 1, HashSet::new());
     let vertex1_id = vertex1.id().clone();
     dag.insert(vertex1).unwrap();
-    
+
     // Try to create a vertex in a lower layer referencing a higher layer
     let mut parents = HashSet::new();
     parents.insert(vertex1_id);
     let data2 = TestData { value: 2 };
     let vertex2 = Vertex::from_data(data2, 0, parents);
-    
+
     assert!(dag.insert_checked(vertex2).is_err());
 }
 
 #[tokio::test]
 async fn test_dag_complex_hierarchy() {
     let mut dag: Dag<TestData> = Dag::new(0);
-    
+
     // Layer 1: Two vertices
     let vertex1_1 = Vertex::from_data(TestData { value: 11 }, 1, HashSet::new());
     let vertex1_2 = Vertex::from_data(TestData { value: 12 }, 1, HashSet::new());
     let id1_1 = vertex1_1.id().clone();
     let id1_2 = vertex1_2.id().clone();
-    
+
     dag.insert(vertex1_1).unwrap();
     dag.insert(vertex1_2).unwrap();
-    
+
     // Layer 2: Two vertices, each with one parent
     let mut parents2_1 = HashSet::new();
     parents2_1.insert(id1_1.clone());
     let mut parents2_2 = HashSet::new();
     parents2_2.insert(id1_2.clone());
-    
+
     let vertex2_1 = Vertex::from_data(TestData { value: 21 }, 2, parents2_1);
     let vertex2_2 = Vertex::from_data(TestData { value: 22 }, 2, parents2_2);
     let id2_1 = vertex2_1.id().clone();
     let id2_2 = vertex2_2.id().clone();
-    
+
     dag.insert_checked(vertex2_1).unwrap();
     dag.insert_checked(vertex2_2).unwrap();
-    
+
     // Layer 3: One vertex with both layer 2 vertices as parents
     let mut parents3 = HashSet::new();
     parents3.insert(id2_1);
     parents3.insert(id2_2);
-    
+
     let vertex3 = Vertex::from_data(TestData { value: 31 }, 3, parents3);
     dag.insert_checked(vertex3).unwrap();
-    
+
     // Verify the structure
     assert_eq!(dag.layer_size(1), 2);
     assert_eq!(dag.layer_size(2), 2);
     assert_eq!(dag.layer_size(3), 1);
     assert_eq!(dag.height(), 3);
-} 
+}

--- a/src/types/tests/dag_tests.rs
+++ b/src/types/tests/dag_tests.rs
@@ -2,8 +2,7 @@ use std::collections::HashSet;
 
 use crate::types::{
     dag::{Dag, DagError, Vertex},
-    traits::{AsBytes, Hash},
-    Digest,
+    traits::AsBytes,
 };
 
 #[derive(Clone, Debug)]

--- a/src/types/tests/dag_tests.rs
+++ b/src/types/tests/dag_tests.rs
@@ -35,10 +35,16 @@ async fn test_dag_creation_and_basic_ops() {
     let data = TestData { value: 1 };
     let parents = HashSet::new();
     let vertex = Vertex::from_data(data, 1, parents);
+    let vertex_id = vertex.id().clone();
     
-    dag.insert(vertex.clone()).unwrap();
+    dag.insert(vertex).unwrap();
     assert_eq!(dag.height(), 1);
     assert_eq!(dag.layer_size(1), 1);
+    
+    // Test vertex retrieval
+    let retrieved = dag.get_vertex(&vertex_id).unwrap();
+    assert_eq!(retrieved.data().value, 1);
+    assert_eq!(retrieved.layer(), 1);
 }
 
 #[tokio::test]
@@ -122,21 +128,6 @@ async fn test_dag_multiple_parents() {
     
     dag.insert_checked(child_vertex).unwrap();
     assert_eq!(dag.layer_size(2), 1);
-}
-
-#[tokio::test]
-async fn test_dag_vertex_retrieval() {
-    let mut dag: Dag<TestData> = Dag::new(0);
-    
-    let data = TestData { value: 1 };
-    let vertex = Vertex::from_data(data, 1, HashSet::new());
-    let vertex_id = vertex.id().clone();
-    
-    dag.insert(vertex).unwrap();
-    
-    let retrieved = dag.get_vertex(&vertex_id).unwrap();
-    assert_eq!(retrieved.data().value, 1);
-    assert_eq!(retrieved.layer(), 1);
 }
 
 #[tokio::test]

--- a/src/types/tests/dag_tests.rs
+++ b/src/types/tests/dag_tests.rs
@@ -1,0 +1,201 @@
+use std::collections::HashSet;
+
+use crate::types::{
+    dag::{Dag, DagError, Vertex},
+    traits::{AsBytes, Hash},
+};
+
+#[derive(Clone, Debug)]
+struct TestData {
+    value: u64,
+}
+
+impl Hash for TestData {
+    fn hash(&self) -> String {
+        format!("test_data_{}", self.value)
+    }
+}
+
+impl AsBytes for TestData {
+    fn bytes(&self) -> Vec<u8> {
+        self.value.to_be_bytes().to_vec()
+    }
+}
+
+#[tokio::test]
+async fn test_dag_creation_and_basic_ops() {
+    let base_layer = 0;
+    let mut dag: Dag<TestData> = Dag::new(base_layer);
+    
+    // Test initial state
+    assert_eq!(dag.height(), base_layer);
+    assert_eq!(dag.base_layer(), base_layer);
+    
+    // Test vertex insertion
+    let data = TestData { value: 1 };
+    let parents = HashSet::new();
+    let vertex = Vertex::from_data(data, 1, parents);
+    
+    dag.insert(vertex.clone()).unwrap();
+    assert_eq!(dag.height(), 1);
+    assert_eq!(dag.layer_size(1), 1);
+}
+
+#[tokio::test]
+async fn test_dag_parent_child_relationships() {
+    let mut dag: Dag<TestData> = Dag::new(0);
+    
+    // Create parent vertex
+    let parent_data = TestData { value: 1 };
+    let parent_vertex = Vertex::from_data(parent_data, 1, HashSet::new());
+    let parent_id = parent_vertex.id().clone();
+    dag.insert(parent_vertex).unwrap();
+    
+    // Create child vertex with parent reference
+    let mut parents = HashSet::new();
+    parents.insert(parent_id);
+    let child_data = TestData { value: 2 };
+    let child_vertex = Vertex::from_data(child_data, 2, parents);
+    
+    dag.insert_checked(child_vertex).unwrap();
+}
+
+#[tokio::test]
+async fn test_dag_invalid_parent() {
+    let mut dag: Dag<TestData> = Dag::new(0);
+    
+    let mut parents = HashSet::new();
+    parents.insert("non_existent_parent".to_string());
+    let data = TestData { value: 1 };
+    let vertex = Vertex::from_data(data, 1, parents);
+    
+    match dag.insert_checked(vertex) {
+        Err(DagError::MissingParents(_)) => (),
+        _ => panic!("Expected MissingParents error"),
+    }
+}
+
+#[tokio::test]
+async fn test_dag_layer_operations() {
+    let mut dag: Dag<TestData> = Dag::new(0);
+    
+    // Insert vertices in different layers
+    for i in 1..=3 {
+        let data = TestData { value: i };
+        let vertex = Vertex::from_data(data, i as u64, HashSet::new());
+        dag.insert(vertex).unwrap();
+    }
+    
+    // Test layer queries
+    assert_eq!(dag.layer_size(1), 1);
+    assert_eq!(dag.layer_size(2), 1);
+    assert_eq!(dag.layer_size(3), 1);
+    
+    let layer_2_vertices = dag.layer_vertices(2);
+    assert_eq!(layer_2_vertices.len(), 1);
+    assert_eq!(layer_2_vertices[0].data().value, 2);
+}
+
+#[tokio::test]
+async fn test_dag_multiple_parents() {
+    let mut dag: Dag<TestData> = Dag::new(0);
+    
+    // Create two parent vertices
+    let parent1_data = TestData { value: 1 };
+    let parent2_data = TestData { value: 2 };
+    let parent1_vertex = Vertex::from_data(parent1_data, 1, HashSet::new());
+    let parent2_vertex = Vertex::from_data(parent2_data, 1, HashSet::new());
+    
+    let parent1_id = parent1_vertex.id().clone();
+    let parent2_id = parent2_vertex.id().clone();
+    
+    dag.insert(parent1_vertex).unwrap();
+    dag.insert(parent2_vertex).unwrap();
+    
+    // Create child with multiple parents
+    let mut parents = HashSet::new();
+    parents.insert(parent1_id);
+    parents.insert(parent2_id);
+    
+    let child_data = TestData { value: 3 };
+    let child_vertex = Vertex::from_data(child_data, 2, parents);
+    
+    dag.insert_checked(child_vertex).unwrap();
+    assert_eq!(dag.layer_size(2), 1);
+}
+
+#[tokio::test]
+async fn test_dag_vertex_retrieval() {
+    let mut dag: Dag<TestData> = Dag::new(0);
+    
+    let data = TestData { value: 1 };
+    let vertex = Vertex::from_data(data, 1, HashSet::new());
+    let vertex_id = vertex.id().clone();
+    
+    dag.insert(vertex).unwrap();
+    
+    let retrieved = dag.get_vertex(&vertex_id).unwrap();
+    assert_eq!(retrieved.data().value, 1);
+    assert_eq!(retrieved.layer(), 1);
+}
+
+#[tokio::test]
+async fn test_dag_cyclic_insertion_prevention() {
+    let mut dag: Dag<TestData> = Dag::new(0);
+    
+    // Create first vertex
+    let data1 = TestData { value: 1 };
+    let vertex1 = Vertex::from_data(data1, 1, HashSet::new());
+    let vertex1_id = vertex1.id().clone();
+    dag.insert(vertex1).unwrap();
+    
+    // Try to create a vertex in a lower layer referencing a higher layer
+    let mut parents = HashSet::new();
+    parents.insert(vertex1_id);
+    let data2 = TestData { value: 2 };
+    let vertex2 = Vertex::from_data(data2, 0, parents);
+    
+    assert!(dag.insert_checked(vertex2).is_err());
+}
+
+#[tokio::test]
+async fn test_dag_complex_hierarchy() {
+    let mut dag: Dag<TestData> = Dag::new(0);
+    
+    // Layer 1: Two vertices
+    let vertex1_1 = Vertex::from_data(TestData { value: 11 }, 1, HashSet::new());
+    let vertex1_2 = Vertex::from_data(TestData { value: 12 }, 1, HashSet::new());
+    let id1_1 = vertex1_1.id().clone();
+    let id1_2 = vertex1_2.id().clone();
+    
+    dag.insert(vertex1_1).unwrap();
+    dag.insert(vertex1_2).unwrap();
+    
+    // Layer 2: Two vertices, each with one parent
+    let mut parents2_1 = HashSet::new();
+    parents2_1.insert(id1_1.clone());
+    let mut parents2_2 = HashSet::new();
+    parents2_2.insert(id1_2.clone());
+    
+    let vertex2_1 = Vertex::from_data(TestData { value: 21 }, 2, parents2_1);
+    let vertex2_2 = Vertex::from_data(TestData { value: 22 }, 2, parents2_2);
+    let id2_1 = vertex2_1.id().clone();
+    let id2_2 = vertex2_2.id().clone();
+    
+    dag.insert_checked(vertex2_1).unwrap();
+    dag.insert_checked(vertex2_2).unwrap();
+    
+    // Layer 3: One vertex with both layer 2 vertices as parents
+    let mut parents3 = HashSet::new();
+    parents3.insert(id2_1);
+    parents3.insert(id2_2);
+    
+    let vertex3 = Vertex::from_data(TestData { value: 31 }, 3, parents3);
+    dag.insert_checked(vertex3).unwrap();
+    
+    // Verify the structure
+    assert_eq!(dag.layer_size(1), 2);
+    assert_eq!(dag.layer_size(2), 2);
+    assert_eq!(dag.layer_size(3), 1);
+    assert_eq!(dag.height(), 3);
+} 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -70,4 +70,8 @@ impl<T: Clone> CircularBuffer<T> {
         self.buffer = vec![None; self.size];
         res
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.buffer.iter().filter_map(|x| x.as_ref())
+    }
 }


### PR DESCRIPTION
This PR :
Moved from static test directories to dynamic temp directories
Updated Committee implementation with test helpers
Improved test utilities and fixtures

and adds following tests :

* Header Tests :
Tests initialization, quorum waiting, sync status handling, and digest buffer operations
Includes edge cases like empty digests and timeout scenarios
Added tests for multiple rounds and invalid vote handling

  test_header_builder_initialization()  - Tests proper setup of HeaderBuilder
  test_wait_for_quorum()                     - Tests quorum collection mechanism
  test_header_builder_sync_status()          - Tests sync state handling
  test_header_builder_with_empty_digests()   - Edge case: empty digest handling
  test_header_builder_multiple_rounds()       - Tests multi-round header building
  test_header_builder_quorum_timeout()       - Tests timeout handling
  test_header_builder_invalid_votes()        - Tests invalid vote rejection
  test_header_builder_digest_buffer()        - Tests digest buffer operations

* Primary Synchronizer Tests :
Tests concurrent request handling, retry logic on failures, partial response handling, invalid response data scenarios

  test_synchronizer_concurrent_requests()     - Tests parallel request handling
  test_synchronizer_retry_on_failure()       - Tests retry mechanism
  test_synchronizer_multiple_peers()         - Tests multi-peer interactions
  test_synchronizer_invalid_response_data()  - Tests invalid response handling

* Fetcher Tests :
Tests basic fetching operations, timeout handling, error responses
Covers multiple peer scenarios and response validation
Tests retry mechanisms on failed fetches

  test_fetcher_basic()                       - Tests basic fetch operations
  test_fetcher_empty()
  test_fetcher_timeout()                     - Tests timeout handling
  test_fetcher_error_response()              - Tests error response handling
  test_fetcher_multiple_peers()              - Tests fetching from multiple peers
  test_fetcher_single_request()              - Tests single request flow

* DAG tests :
Tests basic DAG creation and operations, parent-child relationships, invalid parent scenarios, layer operations, complex hierarchies with multiple parents, cyclic insertion prevention

  test_dag_creation_and_basic_ops()          - Tests basic DAG operations
  test_dag_parent_child_relationships()      - Tests relationship validations
  test_dag_invalid_parent()                  - Tests invalid parent handling
  test_dag_layer_operations()                - Tests layer-based operations
  test_dag_multiple_parents()                - Tests multiple parent scenarios
  test_dag_cyclic_insertion_prevention()     - Tests cycle prevention
  test_dag_complex_hierarchy()               - Tests complex DAG structures

The `cargo test` passes :
```
running 48 tests
test primary::tests::header_tests::test_header_builder_digest_buffer ... ok
test primary::tests::header_tests::test_header_builder_initialization ... ok
test db::test::test_db ... ok
test primary::header_elector::test::test_first_round_valid_header_digests_stored ... ok
test primary::digests_receiver::tests::test_single_digest_received ... ok
test primary::digests_receiver::tests::test_multiple_under_capacity_digests_received ... ok
test primary::tests::header_tests::test_wait_for_quorum ... ok
test primary::tests::header_tests::test_header_builder_invalid_votes ... ok
test primary::digests_receiver::tests::test_multiple_over_capacity_digests_received ... ok
test synchronizer::feeder::test::feeder_failed_recovery ... ok
test synchronizer::tests::fetcher_tests::test_fetcher_basic ... ok
test synchronizer::tests::fetcher_tests::test_fetcher_empty ... ok
test synchronizer::feeder::test::feeder_full_recovery ... ok
test synchronizer::feeder::test::feeder_partial_recovery ... ok
test primary::digests_receiver::tests::test_multiple_very_over_capacity_digests_received ... ok
test synchronizer::tests::fetcher_tests::test_fetcher_timeout ... ok
test primary::tests::header_tests::test_header_builder_sync_status ... ok
test primary::tests::header_tests::test_header_builder_quorum_timeout ... ok
test primary::tests::header_tests::test_header_builder_with_empty_digests ... ok
test synchronizer::tests::fetcher_tests::test_fetcher_error_response ... ok
test types::dag::test::test_one_child_one_parent_check ... ok
test types::tests::dag_tests::test_dag_complex_hierarchy ... ok
test types::tests::dag_tests::test_dag_creation_and_basic_ops ... ok
test types::tests::dag_tests::test_dag_cyclic_insertion_prevention ... ok
test types::tests::dag_tests::test_dag_invalid_parent ... ok
test types::tests::dag_tests::test_dag_layer_operations ... ok
test types::tests::dag_tests::test_dag_multiple_parents ... ok
test types::tests::dag_tests::test_dag_parent_child_relationships ... ok
test worker::batch_maker::test::test_batch_maker_mixed_triggers ... ok
test worker::batch_maker::test::test_batch_maker_no_txs ... ok
test worker::batch_maker::test::test_batch_maker_rapid_transactions ... ok
test worker::batch_maker::test::test_batch_maker_size_trigger ... ok
test worker::batch_maker::test::test_batch_maker_timeout_trigger ... ok
test synchronizer::tests::fetcher_tests::test_fetcher_multiple_peers ... ok
test synchronizer::tests::fetcher_tests::test_fetcher_single_request ... ok
test synchronizer::tests::synchronizer_tests::test_synchronizer_concurrent_requests ... ok
test worker::batch_receiver::test::test_cancelled ... ok
test worker::quorum_waiter::test::test_cancelled ... ok
test worker::batch_receiver::test::test_single_batch_acknowledgement ... ok
test worker::quorum_waiter::test::test_batch_forgotten_after_quorum_received ... ok
test worker::quorum_waiter::test::test_duplicates_acknowledgements ... ok
test worker::quorum_waiter::test::test_multiple_batches_multiple_quorum ... ok
test worker::quorum_waiter::test::test_quorum_received ... ok
test worker::quorum_waiter::test::test_multiple_batches_single_quorum ... ok
test synchronizer::tests::synchronizer_tests::test_synchronizer_multiple_peers ... ok
test synchronizer::tests::synchronizer_tests::test_synchronizer_retry_on_failure ... ok
test primary::tests::header_tests::test_header_builder_multiple_rounds ... ok
test synchronizer::tests::synchronizer_tests::test_synchronizer_invalid_response_data ... ok

test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s
```